### PR TITLE
Check if Telegram is installed on device

### DIFF
--- a/Source/Errors.swift
+++ b/Source/Errors.swift
@@ -6,4 +6,5 @@ public enum StickersError: Error {
     case countLimitExceeded
     case dataTypeMismatch
     case setIsEmpty
+    case telegramNotInstalled
 }

--- a/Source/IPC.swift
+++ b/Source/IPC.swift
@@ -29,6 +29,8 @@ struct IPC {
             } else {
                 UIApplication.shared.openURL(ImportURL)
             }
+        } else {
+            return false
         }
         
         return true

--- a/Source/StickerSet.swift
+++ b/Source/StickerSet.swift
@@ -142,6 +142,8 @@ public class StickerSet {
         }
         result["stickers"] = stickers
         
-        let _ = IPC.send(json: result)
+        if !IPC.send(json: result) {
+            throw StickersError.telegramNotInstalled
+        }
     }
 }


### PR DESCRIPTION
Added missing warning to check if telegram is installed on device while importing stickers.
Publishing a new Release version would be appreciated.